### PR TITLE
Patch#2 Fixtures for Frontend Tests, Allow Empty Search Query

### DIFF
--- a/frontend/src/components/core/Navbar.tsx
+++ b/frontend/src/components/core/Navbar.tsx
@@ -72,7 +72,7 @@ export default function Navbar() {
                 className="text-sm py-1 pl-10 text-black border border-slate-200 w-full rounded-sm focus:outline-none"
                 type="text"
                 placeholder="Search for a title"
-                required={true}
+                required={false}
                 value={searchInput}
                 onChange={handleInputChange}
               />

--- a/frontend/src/fixtures/movies.ts
+++ b/frontend/src/fixtures/movies.ts
@@ -1,0 +1,40 @@
+export const moviesData = [
+	{
+		id: "1",
+		title: "Inception",
+		description:
+			"Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
+		releaseYear: 2010,
+		durationHours: 2,
+		durationMinutes: 28,
+		reviewCount: 1,
+		posterUrl: "https://picsum.photos/seed/Inception/500/750",
+		trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo",
+	},
+	{
+		id: "2",
+		title: "Pulp Fiction",
+		description:
+			"Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
+		releaseYear: 2010,
+		durationHours: 2,
+		durationMinutes: 28,
+		reviewCount: 1,
+		posterUrl: "https://picsum.photos/seed/Inception/500/750",
+		trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo",
+	},
+	{
+		id: "3",
+		title: "The Godfather",
+		description:
+			"Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
+		releaseYear: 2010,
+		durationHours: 2,
+		durationMinutes: 28,
+		reviewCount: 1,
+		posterUrl: "https://picsum.photos/seed/Inception/500/750",
+		trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo",
+	},
+];
+
+export const moviesDetailsData = {};

--- a/frontend/src/fixtures/movies.ts
+++ b/frontend/src/fixtures/movies.ts
@@ -37,4 +37,34 @@ export const moviesData = [
 	},
 ];
 
-export const moviesDetailsData = {};
+export const moviesDetailsData = {
+	movie: {
+		id: "1",
+		title: "Inception",
+		description:
+			"Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
+		releaseYear: 2010,
+		durationHours: 2,
+		durationMinutes: 28,
+		reviewCount: 1,
+		posterUrl: "https://picsum.photos/seed/Inception/500/750",
+		trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo",
+	},
+	rank: 1,
+	reviews: [
+		{
+			movieId: "1",
+			userId: "1",
+			comment: "Great movie!",
+			createdAt: "2024-05-20T14:42:15.850Z",
+			edited: false,
+			rating: 4,
+			user: {
+				email: "abd@gmail.com",
+				firstName: "Abdullah",
+				lastName: "Umer",
+				id: "1",
+			},
+		},
+	],
+};

--- a/frontend/src/fixtures/reviews.ts
+++ b/frontend/src/fixtures/reviews.ts
@@ -1,0 +1,1 @@
+export const reviewData = {};

--- a/frontend/src/fixtures/users.ts
+++ b/frontend/src/fixtures/users.ts
@@ -1,0 +1,10 @@
+export const userData = {
+	user: {
+		id: "1",
+		firstName: "Abdullah",
+		lastName: "Umer",
+		email: "abd@gmail.com",
+	},
+	token:
+		"eyJhbGciOiJIUzI1NiJ9eyJpZCI6MX0JAWUkAU2mWhxcd6MS8r9pd44yBIfkEBmpr3WLeqIccM",
+};

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -113,22 +113,20 @@ describe("Home Component", () => {
       expect(mockGetNewMovies).toHaveBeenCalled();
     });
 
-    await waitFor(() => {
-      expect(toast).toHaveBeenCalledWith({
-        variant: "destructive",
-        title: "An error occured",
-        description: "There was a problem fetching ranked movies.",
-      });
-      expect(toast).toHaveBeenCalledWith({
-        variant: "destructive",
-        title: "An error occured",
-        description: "There was a problem fetching featured movies.",
-      });
-      expect(toast).toHaveBeenCalledWith({
-        variant: "destructive",
-        title: "An error occured",
-        description: "There was a problem fetching new movies.",
-      });
+    expect(toast).toHaveBeenCalledWith({
+      variant: "destructive",
+      title: "An error occured",
+      description: "There was a problem fetching ranked movies.",
+    });
+    expect(toast).toHaveBeenCalledWith({
+      variant: "destructive",
+      title: "An error occured",
+      description: "There was a problem fetching featured movies.",
+    });
+    expect(toast).toHaveBeenCalledWith({
+      variant: "destructive",
+      title: "An error occured",
+      description: "There was a problem fetching new movies.",
     });
   });
 });

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -60,21 +60,19 @@ describe("Home Component", () => {
       </BrowserRouter>
     );
 
+    expect(screen.getByText(/Top Ranked/i)).toBeInTheDocument();
+    expect(screen.getByText(/Featured Today/i)).toBeInTheDocument();
+    expect(screen.getByText(/Newly Added/i)).toBeInTheDocument();
+
     await waitFor(() => {
       expect(mockGetAllRankedMovies).toHaveBeenCalled();
       expect(mockGetFeaturedMovies).toHaveBeenCalled();
       expect(mockGetNewMovies).toHaveBeenCalled();
     });
 
-    expect(screen.getByText(/Top Ranked/i)).toBeInTheDocument();
-    expect(screen.getByText(/Featured Today/i)).toBeInTheDocument();
-    expect(screen.getByText(/Newly Added/i)).toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(screen.getByText(new RegExp(moviesData[0].title, "i"))).toBeInTheDocument();
-      expect(screen.getByText(new RegExp(moviesData[1].title, "i"))).toBeInTheDocument();
-      expect(screen.getByText(new RegExp(moviesData[2].title, "i"))).toBeInTheDocument();
-    });
+    expect(screen.getByText(new RegExp(moviesData[0].title, "i"))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(moviesData[1].title, "i"))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(moviesData[2].title, "i"))).toBeInTheDocument();
   });
 
   test("handles errors when fetching movies", async () => {

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter } from "react-router-dom";
 import Home from "./Home";
 import { getAllRankedMovies, getFeaturedMovies, getNewMovies } from "@/api/movies";
 import { useToast } from "@/components/ui/use-toast";
+import { moviesData } from "@/fixtures/movies";
 
 jest.mock("@/api/movies");
 jest.mock("@/components/ui/use-toast");
@@ -35,51 +36,21 @@ describe("Home Component", () => {
       error: false,
       message: "New movies successfully fetched",
       data: {
-        movies: [{
-          id: "1",
-          title: "Inception",
-          description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-          releaseYear: 2010,
-          durationHours: 2,
-          durationMinutes: 28,
-          reviewCount: 1,
-          posterUrl: "https://picsum.photos/seed/Inception/500/750",
-          trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-        }],
+        movies: [moviesData[0]],
       },
     });
     mockGetFeaturedMovies.mockResolvedValue({
       error: false,
       message: "New movies successfully fetched",
       data: {
-        movies: [{
-          id: "1",
-          title: "Pulp Fiction",
-          description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-          releaseYear: 2010,
-          durationHours: 2,
-          durationMinutes: 28,
-          reviewCount: 1,
-          posterUrl: "https://picsum.photos/seed/Inception/500/750",
-          trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-        }],
+        movies: [moviesData[1]],
       },
     });
     mockGetNewMovies.mockResolvedValue({
       error: false,
       message: "All movies successfully fetched",
       data: {
-        movies: [{
-          id: "1",
-          title: "The Godfather",
-          description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-          releaseYear: 2010,
-          durationHours: 2,
-          durationMinutes: 28,
-          reviewCount: 1,
-          posterUrl: "https://picsum.photos/seed/Inception/500/750",
-          trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-        }],
+        movies: [moviesData[2]],
       },
     });
 
@@ -100,9 +71,9 @@ describe("Home Component", () => {
     expect(screen.getByText(/Newly Added/i)).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.getByText(/Inception/i)).toBeInTheDocument();
-      expect(screen.getByText(/Pulp Fiction/i)).toBeInTheDocument();
-      expect(screen.getByText(/The Godfather/i)).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(moviesData[0].title, "i"))).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(moviesData[1].title, "i"))).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(moviesData[2].title, "i"))).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -4,6 +4,7 @@ import Login from "./Login";
 import { login } from "@/api/auth";
 import { useAuth } from "@/hooks";
 import { useToast } from "@/components/ui/use-toast";
+import { userData } from "@/fixtures/users";
 
 jest.mock("@/api/auth");
 jest.mock("@/hooks");
@@ -48,10 +49,10 @@ describe("Login Component", () => {
     const emailInput = screen.getByLabelText(/Email/i);
     const passwordInput = screen.getByLabelText(/Password/i);
 
-    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+    fireEvent.change(emailInput, { target: { value: "abd@gmail.com" } });
     fireEvent.change(passwordInput, { target: { value: "password123" } });
 
-    expect(emailInput).toHaveValue("test@example.com");
+    expect(emailInput).toHaveValue("abd@gmail.com");
     expect(passwordInput).toHaveValue("password123");
   });
 
@@ -59,15 +60,7 @@ describe("Login Component", () => {
     mockLogin.mockResolvedValue({
       error: false,
       message: "Login successful",
-      data: {
-        user: {
-          id: "1",
-          firstName: "Test",
-          lastName: "User",
-          email: "test@example.com",
-        },
-        token: "eyJhbGciOiJIUzI1NiJ9eyJpZCI6MX0JAWUkAU2mWhxcd6MS8r9pd44yBIfkEBmpr3WLeqIccM",
-      },
+      data: userData,
     });
 
     render(
@@ -80,25 +73,17 @@ describe("Login Component", () => {
     const passwordInput = screen.getByLabelText(/Password/i);
     const submitButton = screen.getByRole("button", { name: /Login/i });
 
-    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+    fireEvent.change(emailInput, { target: { value: "abd@gmail.com" } });
     fireEvent.change(passwordInput, { target: { value: "password123" } });
 
     fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(mockLogin).toHaveBeenCalledWith({
-        email: "test@example.com",
+        email: "abd@gmail.com",
         password: "password123"
       });
-      expect(saveUser).toHaveBeenCalledWith({
-        user: {
-          id: "1",
-          firstName: "Test",
-          lastName: "User",
-          email: "test@example.com",
-        },
-        token: "eyJhbGciOiJIUzI1NiJ9eyJpZCI6MX0JAWUkAU2mWhxcd6MS8r9pd44yBIfkEBmpr3WLeqIccM",
-      });
+      expect(saveUser).toHaveBeenCalledWith(userData);
       expect(toast).toHaveBeenCalledWith({
         variant: "default",
         title: "Success",
@@ -127,14 +112,14 @@ describe("Login Component", () => {
     const passwordInput = screen.getByLabelText(/Password/i);
     const submitButton = screen.getByRole("button", { name: /Login/i });
 
-    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+    fireEvent.change(emailInput, { target: { value: "abd@gmail.com" } });
     fireEvent.change(passwordInput, { target: { value: "password123" } });
 
     fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(mockLogin).toHaveBeenCalledWith({
-        email: "test@example.com",
+        email: "abd@gmail.com",
         password: "password123"
       });
       expect(toast).toHaveBeenCalledWith({

--- a/frontend/src/pages/MovieDetails.test.tsx
+++ b/frontend/src/pages/MovieDetails.test.tsx
@@ -5,6 +5,8 @@ import { getMovieById } from "@/api/movies";
 import { addReview, editReview, deleteReview } from "@/api/review";
 import { useAuth } from "@/hooks";
 import { useToast } from "@/components/ui/use-toast";
+import { moviesDetailsData } from "@/fixtures/movies";
+import { userData } from "@/fixtures/users";
 
 jest.mock("@/api/movies");
 jest.mock("@/api/review");
@@ -24,15 +26,7 @@ describe("MovieDetails Component", () => {
   beforeEach(() => {
     mockUseToast.mockReturnValue({ toast });
     mockUseAuth.mockReturnValue({
-      authInfo: {
-        user: {
-          id: "1",
-          firstName: "Abdullah",
-          lastName: "Umer",
-          email: "abd@gmail.com",
-        },
-        token: "eyJhbGciOiJIUzI1NiJ9eyJpZCI6MX0JAWUkAU2mWhxcd6MS8r9pd44yBIfkEBmpr3WLeqIccM",
-      },
+      authInfo: userData,
       isLoggedIn: true,
       loadingAuth: false,
     });
@@ -80,17 +74,7 @@ describe("MovieDetails Component", () => {
   test("handles adding a review", async () => {
     mockGetMovieById.mockResolvedValue({
       data: {
-        movie: {
-          id: "1",
-          title: "Inception",
-          description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-          releaseYear: 2010,
-          durationHours: 2,
-          durationMinutes: 28,
-          reviewCount: 1,
-          posterUrl: "https://picsum.photos/seed/Inception/500/750",
-          trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-        },
+        movie: moviesDetailsData.movie,
         rank: 1,
         reviews: [],
       },
@@ -101,8 +85,8 @@ describe("MovieDetails Component", () => {
       message: "Review successfully added",
       data: {
         review: {
-          userId: "1",
-          movieId: "1",
+          userId: userData.user.id,
+          movieId: moviesDetailsData.movie.id,
           comment: "Great movie!",
           rating: 4,
         },
@@ -123,11 +107,15 @@ describe("MovieDetails Component", () => {
       target: { value: "Great movie!" },
     });
 
+    await waitFor(() => {
+      expect(screen.getByTestId(/add-review-button/i)).toBeInTheDocument();
+    });
+
     fireEvent.click(screen.getByTestId(/add-review-button/i));
 
     await waitFor(() => {
       expect(mockAddReview).toHaveBeenCalledWith({
-        movieId: "1",
+        movieId: moviesDetailsData.movie.id,
         rating: 4,
         comment: "Great movie!",
       });
@@ -142,36 +130,7 @@ describe("MovieDetails Component", () => {
 
   test("handles editing a review", async () => {
     mockGetMovieById.mockResolvedValue({
-      data: {
-        movie: {
-          id: "1",
-          title: "Inception",
-          description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-          releaseYear: 2010,
-          durationHours: 2,
-          durationMinutes: 28,
-          reviewCount: 1,
-          posterUrl: "https://picsum.photos/seed/Inception/500/750",
-          trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-        },
-        rank: 1,
-        reviews: [
-          {
-            movieId: "1",
-            userId: "1",
-            comment: "Great movie!",
-            createdAt: "2024-05-20T14:42:15.850Z",
-            edited: false,
-            rating: 4,
-            user: {
-              email: "abd@gmail.com",
-              firstName: "Abdullah",
-              lastName: "Umer",
-              id: "1",
-            }
-          },
-        ],
-      },
+      data: moviesDetailsData,
     });
 
     mockEditReview.mockResolvedValue({
@@ -179,8 +138,8 @@ describe("MovieDetails Component", () => {
       message: "Review successfully updated",
       data: {
         review: {
-          userId: "1",
-          movieId: "1",
+          userId: userData.user.id,
+          movieId: moviesDetailsData.movie.id,
           comment: "Updated review!!",
           rating: 4,
         },
@@ -207,11 +166,15 @@ describe("MovieDetails Component", () => {
       target: { value: "Updated review!!" },
     });
 
+    await waitFor(() => {
+      expect(screen.getByTestId(/save-review-button/i)).toBeInTheDocument();
+    });
+
     fireEvent.click(screen.getByTestId(/save-review-button/i));
 
     await waitFor(() => {
       expect(mockEditReview).toHaveBeenCalledWith({
-        movieId: "1",
+        movieId: moviesDetailsData.movie.id,
         rating: 4,
         comment: "Updated review!!",
       });
@@ -226,36 +189,7 @@ describe("MovieDetails Component", () => {
 
   test("handles deleting a review", async () => {
     mockGetMovieById.mockResolvedValue({
-      data: {
-        movie: {
-          id: "1",
-          title: "Inception",
-          description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-          releaseYear: 2010,
-          durationHours: 2,
-          durationMinutes: 28,
-          reviewCount: 1,
-          posterUrl: "https://picsum.photos/seed/Inception/500/750",
-          trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-        },
-        rank: 1,
-        reviews: [
-          {
-            movieId: "1",
-            userId: "1",
-            comment: "Great movie!",
-            createdAt: "2024-05-20T14:42:15.850Z",
-            edited: false,
-            rating: 4,
-            user: {
-              email: "abd@gmail.com",
-              firstName: "Abdullah",
-              lastName: "Umer",
-              id: "1",
-            }
-          },
-        ],
-      },
+      data: moviesDetailsData,
     });
 
     mockDeleteReview.mockResolvedValue({
@@ -283,7 +217,7 @@ describe("MovieDetails Component", () => {
     fireEvent.click(screen.getByTestId(/delete-review-button/i));
 
     await waitFor(() => {
-      expect(mockDeleteReview).toHaveBeenCalledWith("1");
+      expect(mockDeleteReview).toHaveBeenCalledWith(moviesDetailsData.movie.id);
     });
 
     expect(toast).toHaveBeenCalledWith({
@@ -323,17 +257,7 @@ describe("MovieDetails Component", () => {
   test("handles errors during adding a review", async () => {
     mockGetMovieById.mockResolvedValue({
       data: {
-        movie: {
-          id: "1",
-          title: "Inception",
-          description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-          releaseYear: 2010,
-          durationHours: 2,
-          durationMinutes: 28,
-          reviewCount: 1,
-          posterUrl: "https://picsum.photos/seed/Inception/500/750",
-          trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-        },
+        movie: moviesDetailsData.movie,
         rank: 1,
         reviews: [],
       },
@@ -362,9 +286,14 @@ describe("MovieDetails Component", () => {
       target: { value: "Great movie!" },
     });
 
+    await waitFor(() => {
+      expect(screen.getByTestId(/add-review-button/i)).toBeInTheDocument();
+    });
+
     fireEvent.click(screen.getByTestId(/add-review-button/i));
 
     await waitFor(() => {
+      // does movie does not exist err make logical sense here ?
       expect(mockAddReview).toHaveBeenCalled();
     });
 
@@ -377,36 +306,7 @@ describe("MovieDetails Component", () => {
 
   test("handles errors during editing a review", async () => {
     mockGetMovieById.mockResolvedValue({
-      data: {
-        movie: {
-          id: "1",
-          title: "Inception",
-          description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-          releaseYear: 2010,
-          durationHours: 2,
-          durationMinutes: 28,
-          reviewCount: 1,
-          posterUrl: "https://picsum.photos/seed/Inception/500/750",
-          trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-        },
-        rank: 1,
-        reviews: [
-          {
-            movieId: "1",
-            userId: "1",
-            comment: "Great movie!",
-            createdAt: "2024-05-20T14:42:15.850Z",
-            edited: false,
-            rating: 4,
-            user: {
-              email: "abd@gmail.com",
-              firstName: "Abdullah",
-              lastName: "Umer",
-              id: "1",
-            }
-          },
-        ],
-      },
+      data: moviesDetailsData,
     });
 
     mockEditReview.mockRejectedValue({
@@ -438,9 +338,14 @@ describe("MovieDetails Component", () => {
       target: { value: "Updated review!" },
     });
 
+    await waitFor(() => {
+      expect(screen.getByTestId(/save-review-button/i)).toBeInTheDocument();
+    });
+
     fireEvent.click(screen.getByTestId(/save-review-button/i));
 
     await waitFor(() => {
+      // does review does not exist err make logical sense here ?
       expect(mockEditReview).toHaveBeenCalled();
     });
 
@@ -453,36 +358,7 @@ describe("MovieDetails Component", () => {
 
   test("handles errors during deleting a review", async () => {
     mockGetMovieById.mockResolvedValue({
-      data: {
-        movie: {
-          id: "1",
-          title: "Inception",
-          description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-          releaseYear: 2010,
-          durationHours: 2,
-          durationMinutes: 28,
-          reviewCount: 1,
-          posterUrl: "https://picsum.photos/seed/Inception/500/750",
-          trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-        },
-        rank: 1,
-        reviews: [
-          {
-            movieId: "1",
-            userId: "1",
-            comment: "Great movie!",
-            createdAt: "2024-05-20T14:42:15.850Z",
-            edited: false,
-            rating: 4,
-            user: {
-              email: "abd@gmail.com",
-              firstName: "Abdullah",
-              lastName: "Umer",
-              id: "1",
-            }
-          },
-        ],
-      },
+      data: moviesDetailsData,
     });
 
     mockDeleteReview.mockRejectedValue({
@@ -511,7 +387,8 @@ describe("MovieDetails Component", () => {
     fireEvent.click(screen.getByTestId(/delete-review-button/i));
 
     await waitFor(() => {
-      expect(mockDeleteReview).toHaveBeenCalledWith("1");
+      // does review does not exist err make logical sense here ?
+      expect(mockDeleteReview).toHaveBeenCalledWith(moviesDetailsData.movie.id);
     });
 
     expect(toast).toHaveBeenCalledWith({

--- a/frontend/src/pages/MyMovies.test.tsx
+++ b/frontend/src/pages/MyMovies.test.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter } from "react-router-dom";
 import MyMovies from "./MyMovies";
 import { getMoviesByUser, addMovie, deleteMovie } from "@/api/movies";
 import { useToast } from "@/components/ui/use-toast";
+import { moviesData } from "@/fixtures/movies";
 
 jest.mock("@/api/movies");
 jest.mock("@/components/ui/use-toast");
@@ -28,30 +29,7 @@ describe("MyMovies Component", () => {
       error: false,
       message: "User's movies successfully fetched",
       data: {
-        movies: [
-          {
-            id: "1",
-            title: "Inception",
-            description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-            releaseYear: 2010,
-            durationHours: 2,
-            durationMinutes: 28,
-            reviewCount: 1,
-            posterUrl: "https://picsum.photos/seed/Inception/500/750",
-            trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-          },
-          {
-            id: "2",
-            title: "The Lion King",
-            description: "Disney's live-action adaptation of the classic animated film, retelling the story of Simba, a young lion prince who flees his kingdom after the murder of his father, only to learn the true meaning of responsibility and bravery. Set against the majestic African savanna, this timeless tale explores themes of family, friendship, and destiny.",
-            releaseYear: 2019,
-            durationHours: 1,
-            durationMinutes: 58,
-            reviewCount: 0,
-            posterUrl: "https://picsum.photos/seed/TheLionKing/500/750",
-            trailerUrl: "https://www.youtube.com/embed/oyRxxpD3yNw"
-          },
-        ],
+        movies: moviesData,
       },
     });
 
@@ -61,13 +39,15 @@ describe("MyMovies Component", () => {
       </BrowserRouter>
     );
 
+    expect(screen.getByText(/Your Movies/i)).toBeInTheDocument();
+
     await waitFor(() => {
       expect(mockGetMoviesByUser).toHaveBeenCalled();
     });
 
-    expect(screen.getByText(/Your Movies/i)).toBeInTheDocument();
-    expect(screen.getByText(/Inception/i)).toBeInTheDocument();
-    expect(screen.getByText(/The Lion King/i)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(moviesData[0].title, "i"))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(moviesData[1].title, "i"))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(moviesData[2].title, "i"))).toBeInTheDocument();
   });
 
   test("handles adding a movie", async () => {
@@ -83,17 +63,7 @@ describe("MyMovies Component", () => {
       error: false,
       message: "Movie successfully added",
       data: {
-        movie: {
-          id: "1",
-          title: "Titanic",
-          description: "Another masterpiece from James Cameron, 'Titanic' is a romantic epic that tells the tragic story of the ill-fated maiden voyage of the RMS Titanic. The film centers on the forbidden love between Jack, a poor artist, and Rose, a wealthy young woman, as they navigate the class struggles aboard the ship. Their love story is set against the backdrop of one of the greatest maritime disasters in history.",
-          releaseYear: 1997,
-          durationHours: 3,
-          durationMinutes: 15,
-          reviewCount: 0,
-          posterUrl: "https://picsum.photos/seed/Titanic/500/750",
-          trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo",
-        },
+        movie: moviesData[0],
       },
     });
 
@@ -105,29 +75,28 @@ describe("MyMovies Component", () => {
 
     fireEvent.click(screen.getByText(/Add a Movie/i));
 
-    fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: "Titanic" } });
-    fireEvent.change(screen.getByLabelText(/Description/i), { target: { value: "Another masterpiece from James Cameron, 'Titanic' is a romantic epic that tells the tragic story of the ill-fated maiden voyage of the RMS Titanic. The film centers on the forbidden love between Jack, a poor artist, and Rose, a wealthy young woman, as they navigate the class struggles aboard the ship. Their love story is set against the backdrop of one of the greatest maritime disasters in history." } });
-    fireEvent.change(screen.getByLabelText(/Release Year/i), { target: { value: 1997 } });
-    fireEvent.change(screen.getByLabelText(/Hours/i), { target: { value: 3 } });
-    fireEvent.change(screen.getByLabelText(/Minutes/i), { target: { value: 15 } });
+    fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: moviesData[0].title } });
+    fireEvent.change(screen.getByLabelText(/Description/i), { target: { value: moviesData[0].description } });
+    fireEvent.change(screen.getByLabelText(/Release Year/i), { target: { value: moviesData[0].releaseYear } });
+    fireEvent.change(screen.getByLabelText(/Hours/i), { target: { value: moviesData[0].durationHours } });
+    fireEvent.change(screen.getByLabelText(/Minutes/i), { target: { value: moviesData[0].durationMinutes } });
 
     fireEvent.click(screen.getByTestId(/add-movie-button/i));
 
+    const { id, reviewCount, posterUrl, trailerUrl, ...addMoviePayload } = moviesData[0];
+
     await waitFor(() => {
-      expect(mockAddMovie).toHaveBeenCalledWith({
-        title: "Titanic",
-        description: "Another masterpiece from James Cameron, 'Titanic' is a romantic epic that tells the tragic story of the ill-fated maiden voyage of the RMS Titanic. The film centers on the forbidden love between Jack, a poor artist, and Rose, a wealthy young woman, as they navigate the class struggles aboard the ship. Their love story is set against the backdrop of one of the greatest maritime disasters in history.",
-        releaseYear: 1997,
-        durationHours: 3,
-        durationMinutes: 15,
-      });
+      expect(mockAddMovie).toHaveBeenCalledWith(addMoviePayload);
     });
 
-    expect(screen.getByText(/Titanic/i)).toBeInTheDocument();
-    expect(toast).toHaveBeenCalledWith({
-      variant: "default",
-      title: "Success",
-      description: "Movie successfully added",
+    expect(screen.getByText(new RegExp(moviesData[0].title, "i"))).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith({
+        variant: "default",
+        title: "Success",
+        description: "Movie successfully added",
+      });
     });
   });
 
@@ -136,19 +105,7 @@ describe("MyMovies Component", () => {
       error: false,
       message: "User's movies successfully fetched",
       data: {
-        movies: [
-          {
-            id: "1",
-            title: "Inception",
-            description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-            releaseYear: 2010,
-            durationHours: 2,
-            durationMinutes: 28,
-            reviewCount: 1,
-            posterUrl: "https://picsum.photos/seed/Inception/500/750",
-            trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-          },
-        ],
+        movies: [moviesData[0]],
       },
     });
 
@@ -173,14 +130,17 @@ describe("MyMovies Component", () => {
     fireEvent.click(screen.getByTestId(/delete-movie-button/i));
 
     await waitFor(() => {
-      expect(mockDeleteMovie).toHaveBeenCalledWith("1");
+      expect(mockDeleteMovie).toHaveBeenCalledWith(moviesData[0].id);
     });
 
-    expect(screen.queryByText(/Inception/i)).not.toBeInTheDocument();
-    expect(toast).toHaveBeenCalledWith({
-      variant: "default",
-      title: "Success",
-      description: "Movie successfully deleted",
+    expect(screen.queryByText(new RegExp(moviesData[0].title, "i"))).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith({
+        variant: "default",
+        title: "Success",
+        description: "Movie successfully deleted",
+      });
     });
   });
 
@@ -204,10 +164,12 @@ describe("MyMovies Component", () => {
       expect(mockGetMoviesByUser).toHaveBeenCalled();
     });
 
-    expect(toast).toHaveBeenCalledWith({
-      variant: "destructive",
-      title: "An error occured",
-      description: "There was a problem fetching your movies",
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith({
+        variant: "destructive",
+        title: "An error occured",
+        description: "There was a problem fetching your movies",
+      });
     });
   });
 
@@ -216,7 +178,7 @@ describe("MyMovies Component", () => {
       error: false,
       message: "User's movies successfully fetched",
       data: {
-        movies: [],
+        movies: [moviesData[0]],
       },
     });
 
@@ -237,11 +199,11 @@ describe("MyMovies Component", () => {
 
     fireEvent.click(screen.getByText(/Add a Movie/i));
 
-    fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: "Titanic" } });
-    fireEvent.change(screen.getByLabelText(/Description/i), { target: { value: "Another masterpiece from James Cameron, 'Titanic' is a romantic epic that tells the tragic story of the ill-fated maiden voyage of the RMS Titanic. The film centers on the forbidden love between Jack, a poor artist, and Rose, a wealthy young woman, as they navigate the class struggles aboard the ship. Their love story is set against the backdrop of one of the greatest maritime disasters in history." } });
-    fireEvent.change(screen.getByLabelText(/Release Year/i), { target: { value: 1997 } });
-    fireEvent.change(screen.getByLabelText(/Hours/i), { target: { value: 3 } });
-    fireEvent.change(screen.getByLabelText(/Minutes/i), { target: { value: 15 } });
+    fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: moviesData[0].title } });
+    fireEvent.change(screen.getByLabelText(/Description/i), { target: { value: moviesData[0].description } });
+    fireEvent.change(screen.getByLabelText(/Release Year/i), { target: { value: moviesData[0].releaseYear } });
+    fireEvent.change(screen.getByLabelText(/Hours/i), { target: { value: moviesData[0].durationHours } });
+    fireEvent.change(screen.getByLabelText(/Minutes/i), { target: { value: moviesData[0].durationMinutes } });
 
     fireEvent.click(screen.getByTestId(/add-movie-button/i));
 
@@ -249,10 +211,12 @@ describe("MyMovies Component", () => {
       expect(mockAddMovie).toHaveBeenCalled();
     });
 
-    expect(toast).toHaveBeenCalledWith({
-      variant: "destructive",
-      title: "An error occured",
-      description: "A movie with this title already exists",
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith({
+        variant: "destructive",
+        title: "An error occured",
+        description: "A movie with this title already exists",
+      });
     });
   });
 
@@ -261,19 +225,7 @@ describe("MyMovies Component", () => {
       error: false,
       message: "User's movies successfully fetched",
       data: {
-        movies: [
-          {
-            id: "1",
-            title: "Inception",
-            description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-            releaseYear: 2010,
-            durationHours: 2,
-            durationMinutes: 28,
-            reviewCount: 1,
-            posterUrl: "https://picsum.photos/seed/Inception/500/750",
-            trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-          },
-        ],
+        movies: [moviesData[0]],
       },
     });
 
@@ -299,13 +251,16 @@ describe("MyMovies Component", () => {
     fireEvent.click(screen.getByTestId(/delete-movie-button/i));
 
     await waitFor(() => {
-      expect(mockDeleteMovie).toHaveBeenCalledWith("1");
+      // doesn't actually make sense to call with id of your movie and then have it err with movie does not exist.
+      expect(mockDeleteMovie).toHaveBeenCalledWith(moviesData[0].id);
     });
 
-    expect(toast).toHaveBeenCalledWith({
-      variant: "destructive",
-      title: "An error occured",
-      description: "Movie does not exist",
-    });
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith({
+        variant: "destructive",
+        title: "An error occured",
+        description: "Movie does not exist",
+      });
+    })
   });
 });

--- a/frontend/src/pages/MyMovies.test.tsx
+++ b/frontend/src/pages/MyMovies.test.tsx
@@ -170,7 +170,7 @@ describe("MyMovies Component", () => {
       expect(mockGetMoviesByUser).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByText(/Delete/i));
+    fireEvent.click(screen.getByTestId(/delete-movie-button/i));
 
     await waitFor(() => {
       expect(mockDeleteMovie).toHaveBeenCalledWith("1");
@@ -296,7 +296,7 @@ describe("MyMovies Component", () => {
       expect(mockGetMoviesByUser).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByText(/Delete/i));
+    fireEvent.click(screen.getByTestId(/delete-movie-button/i));
 
     await waitFor(() => {
       expect(mockDeleteMovie).toHaveBeenCalledWith("1");

--- a/frontend/src/pages/MyMovies.test.tsx
+++ b/frontend/src/pages/MyMovies.test.tsx
@@ -91,12 +91,10 @@ describe("MyMovies Component", () => {
 
     expect(screen.getByText(new RegExp(moviesData[0].title, "i"))).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(toast).toHaveBeenCalledWith({
-        variant: "default",
-        title: "Success",
-        description: "Movie successfully added",
-      });
+    expect(toast).toHaveBeenCalledWith({
+      variant: "default",
+      title: "Success",
+      description: "Movie successfully added",
     });
   });
 
@@ -135,12 +133,10 @@ describe("MyMovies Component", () => {
 
     expect(screen.queryByText(new RegExp(moviesData[0].title, "i"))).not.toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(toast).toHaveBeenCalledWith({
-        variant: "default",
-        title: "Success",
-        description: "Movie successfully deleted",
-      });
+    expect(toast).toHaveBeenCalledWith({
+      variant: "default",
+      title: "Success",
+      description: "Movie successfully deleted",
     });
   });
 
@@ -164,12 +160,10 @@ describe("MyMovies Component", () => {
       expect(mockGetMoviesByUser).toHaveBeenCalled();
     });
 
-    await waitFor(() => {
-      expect(toast).toHaveBeenCalledWith({
-        variant: "destructive",
-        title: "An error occured",
-        description: "There was a problem fetching your movies",
-      });
+    expect(toast).toHaveBeenCalledWith({
+      variant: "destructive",
+      title: "An error occured",
+      description: "There was a problem fetching your movies",
     });
   });
 
@@ -211,12 +205,10 @@ describe("MyMovies Component", () => {
       expect(mockAddMovie).toHaveBeenCalled();
     });
 
-    await waitFor(() => {
-      expect(toast).toHaveBeenCalledWith({
-        variant: "destructive",
-        title: "An error occured",
-        description: "A movie with this title already exists",
-      });
+    expect(toast).toHaveBeenCalledWith({
+      variant: "destructive",
+      title: "An error occured",
+      description: "A movie with this title already exists",
     });
   });
 
@@ -255,12 +247,10 @@ describe("MyMovies Component", () => {
       expect(mockDeleteMovie).toHaveBeenCalledWith(moviesData[0].id);
     });
 
-    await waitFor(() => {
-      expect(toast).toHaveBeenCalledWith({
-        variant: "destructive",
-        title: "An error occured",
-        description: "Movie does not exist",
-      });
-    })
+    expect(toast).toHaveBeenCalledWith({
+      variant: "destructive",
+      title: "An error occured",
+      description: "Movie does not exist",
+    });
   });
 });

--- a/frontend/src/pages/MyMovies.tsx
+++ b/frontend/src/pages/MyMovies.tsx
@@ -500,6 +500,7 @@ export default function MyMovies() {
                           <Pencil className="w-5" />
                         </button>
                         <button
+                          data-testid="delete-movie-button"
                           onClick={() => handleDeleteMovie(movie.id)}
                           className="w-full flex flex-row justify-center bg-[#3abab4] border border-[#3abab4]/50 shadow-[#3abab4]/15 shadow-lg hover:bg-[#3abab4]/75 hover:shadow-black/5 active:bg-[#3abab4]/50 active:shadow-black active:shadow-inner active:border-black/25 text-white px-4 py-1 rounded-sm"
                         >

--- a/frontend/src/pages/Search.test.tsx
+++ b/frontend/src/pages/Search.test.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, useSearchParams } from "react-router-dom";
 import Search from "./Search";
 import { getSearchResults } from "@/api/movies";
 import { useToast } from "@/components/ui/use-toast";
+import { moviesData } from "@/fixtures/movies";
 
 jest.mock("@/api/movies");
 jest.mock("@/components/ui/use-toast");
@@ -33,30 +34,7 @@ describe("Search Component", () => {
       error: false,
       message: "New movies successfully fetched",
       data: {
-        movies: [
-          {
-            id: "1",
-            title: "Inception",
-            description: "Directed by Christopher Nolan, 'Inception' is a mind-bending heist film set in a world where technology exists to enter the human mind through dreams. Dom Cobb, a skilled thief, is tasked with the seemingly impossible mission of planting an idea into the mind of a CEO. As he delves deeper into the layers of the subconscious, Cobb must confront his own demons and question the nature of reality.",
-            releaseYear: 2010,
-            durationHours: 2,
-            durationMinutes: 28,
-            reviewCount: 1,
-            posterUrl: "https://picsum.photos/seed/Inception/500/750",
-            trailerUrl: "https://www.youtube.com/embed/ycoY201RTRo"
-          },
-          {
-            id: "2",
-            title: "The Lion King",
-            description: "Disney's live-action adaptation of the classic animated film, retelling the story of Simba, a young lion prince who flees his kingdom after the murder of his father, only to learn the true meaning of responsibility and bravery. Set against the majestic African savanna, this timeless tale explores themes of family, friendship, and destiny.",
-            releaseYear: 2019,
-            durationHours: 1,
-            durationMinutes: 58,
-            reviewCount: 0,
-            posterUrl: "https://picsum.photos/seed/TheLionKing/500/750",
-            trailerUrl: "https://www.youtube.com/embed/oyRxxpD3yNw"
-          },
-        ],
+        movies: moviesData,
       },
     });
 
@@ -70,9 +48,12 @@ describe("Search Component", () => {
       expect(mockGetSearchResults).toHaveBeenCalledWith("test query");
     });
 
-    expect(screen.getByText(/2 results found/i)).toBeInTheDocument();
-    expect(screen.getByText(/Inception/i)).toBeInTheDocument();
-    expect(screen.getByText(/The Lion King/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(new RegExp(`${moviesData.length} results found`, "i"))).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(moviesData[0].title, "i"))).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(moviesData[1].title, "i"))).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(moviesData[2].title, "i"))).toBeInTheDocument();
+    });
   });
 
   test("handles no search results", async () => {
@@ -94,7 +75,9 @@ describe("Search Component", () => {
       expect(mockGetSearchResults).toHaveBeenCalledWith("test query");
     });
 
-    expect(screen.getByText(/No results found/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/No results found/i)).toBeInTheDocument();
+    });
   });
 
   test("handles errors when fetching search results", async () => {

--- a/frontend/src/pages/Search.test.tsx
+++ b/frontend/src/pages/Search.test.tsx
@@ -96,12 +96,10 @@ describe("Search Component", () => {
       expect(mockGetSearchResults).toHaveBeenCalledWith("test query");
     });
 
-    await waitFor(() => {
-      expect(toast).toHaveBeenCalledWith({
-        variant: "destructive",
-        title: "An error occured",
-        description: "There was a problem fetching results.",
-      });
+    expect(toast).toHaveBeenCalledWith({
+      variant: "destructive",
+      title: "An error occured",
+      description: "There was a problem fetching results.",
     });
   });
 });

--- a/frontend/src/pages/Search.test.tsx
+++ b/frontend/src/pages/Search.test.tsx
@@ -48,12 +48,10 @@ describe("Search Component", () => {
       expect(mockGetSearchResults).toHaveBeenCalledWith("test query");
     });
 
-    await waitFor(() => {
-      expect(screen.getByText(new RegExp(`${moviesData.length} results found`, "i"))).toBeInTheDocument();
-      expect(screen.getByText(new RegExp(moviesData[0].title, "i"))).toBeInTheDocument();
-      expect(screen.getByText(new RegExp(moviesData[1].title, "i"))).toBeInTheDocument();
-      expect(screen.getByText(new RegExp(moviesData[2].title, "i"))).toBeInTheDocument();
-    });
+    expect(screen.getByText(new RegExp(`${moviesData.length} results found`, "i"))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(moviesData[0].title, "i"))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(moviesData[1].title, "i"))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(moviesData[2].title, "i"))).toBeInTheDocument();
   });
 
   test("handles no search results", async () => {
@@ -75,9 +73,7 @@ describe("Search Component", () => {
       expect(mockGetSearchResults).toHaveBeenCalledWith("test query");
     });
 
-    await waitFor(() => {
-      expect(screen.getByText(/No results found/i)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/No results found/i)).toBeInTheDocument();
   });
 
   test("handles errors when fetching search results", async () => {

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -17,7 +17,7 @@ export default function Search() {
   // when search params are updated, page re renders and this use effect sets the new query again
   useEffect(() => {
     const searchQueryFromParams = searchParams.get("query");
-    if (searchQueryFromParams) {
+    if (searchQueryFromParams !== null) {
       setSearchQuery(searchQueryFromParams);
     }
   }, [searchParams.get("query")]);

--- a/frontend/src/pages/Signup.test.tsx
+++ b/frontend/src/pages/Signup.test.tsx
@@ -4,6 +4,7 @@ import Signup from "./Signup";
 import { signup } from "@/api/auth";
 import { useAuth } from "@/hooks";
 import { useToast } from "@/components/ui/use-toast";
+import { userData } from "@/fixtures/users";
 
 jest.mock("@/api/auth");
 jest.mock("@/hooks");
@@ -52,14 +53,14 @@ describe("Signup Component", () => {
     const emailInput = screen.getByLabelText(/Email/i);
     const passwordInput = screen.getByLabelText(/Password/i);
 
-    fireEvent.change(firstNameInput, { target: { value: "John" } });
-    fireEvent.change(lastNameInput, { target: { value: "Doe" } });
-    fireEvent.change(emailInput, { target: { value: "john.doe@example.com" } });
+    fireEvent.change(firstNameInput, { target: { value: "Abdullah" } });
+    fireEvent.change(lastNameInput, { target: { value: "Umer" } });
+    fireEvent.change(emailInput, { target: { value: "abd@gmail.com" } });
     fireEvent.change(passwordInput, { target: { value: "password123" } });
 
-    expect(firstNameInput).toHaveValue("John");
-    expect(lastNameInput).toHaveValue("Doe");
-    expect(emailInput).toHaveValue("john.doe@example.com");
+    expect(firstNameInput).toHaveValue("Abdullah");
+    expect(lastNameInput).toHaveValue("Umer");
+    expect(emailInput).toHaveValue("abd@gmail.com");
     expect(passwordInput).toHaveValue("password123");
   });
 
@@ -67,15 +68,7 @@ describe("Signup Component", () => {
     mockSignup.mockResolvedValue({
       error: false,
       message: "Signup successful",
-      data: {
-        user: {
-          id: "1",
-          firstName: "John",
-          lastName: "Doe",
-          email: "john.doe@example.com",
-        },
-        token: "eyJhbGciOiJIUzI1NiJ9eyJpZCI6MX0JAWUkAU2mWhxcd6MS8r9pd44yBIfkEBmpr3WLeqIccM",
-      },
+      data: userData,
     });
 
     render(
@@ -90,29 +83,21 @@ describe("Signup Component", () => {
     const passwordInput = screen.getByLabelText(/Password/i);
     const submitButton = screen.getByRole("button", { name: /Create Account/i });
 
-    fireEvent.change(firstNameInput, { target: { value: "John" } });
-    fireEvent.change(lastNameInput, { target: { value: "Doe" } });
-    fireEvent.change(emailInput, { target: { value: "john.doe@example.com" } });
+    fireEvent.change(firstNameInput, { target: { value: "Abdullah" } });
+    fireEvent.change(lastNameInput, { target: { value: "Umer" } });
+    fireEvent.change(emailInput, { target: { value: "abd@gmail.com" } });
     fireEvent.change(passwordInput, { target: { value: "password123" } });
 
     fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(mockSignup).toHaveBeenCalledWith({
-        firstName: "John",
-        lastName: "Doe",
-        email: "john.doe@example.com",
+        firstName: "Abdullah",
+        lastName: "Umer",
+        email: "abd@gmail.com",
         password: "password123"
       });
-      expect(saveUser).toHaveBeenCalledWith({
-        user: {
-          id: "1",
-          firstName: "John",
-          lastName: "Doe",
-          email: "john.doe@example.com",
-        },
-        token: "eyJhbGciOiJIUzI1NiJ9eyJpZCI6MX0JAWUkAU2mWhxcd6MS8r9pd44yBIfkEBmpr3WLeqIccM",
-      });
+      expect(saveUser).toHaveBeenCalledWith(userData);
       expect(toast).toHaveBeenCalledWith({
         variant: "default",
         title: "Success",
@@ -143,18 +128,18 @@ describe("Signup Component", () => {
     const passwordInput = screen.getByLabelText(/Password/i);
     const submitButton = screen.getByRole("button", { name: /Create Account/i });
 
-    fireEvent.change(firstNameInput, { target: { value: "John" } });
-    fireEvent.change(lastNameInput, { target: { value: "Doe" } });
-    fireEvent.change(emailInput, { target: { value: "john.doe@example.com" } });
+    fireEvent.change(firstNameInput, { target: { value: "Abdullah" } });
+    fireEvent.change(lastNameInput, { target: { value: "Umer" } });
+    fireEvent.change(emailInput, { target: { value: "abd@gmail.com" } });
     fireEvent.change(passwordInput, { target: { value: "password123" } });
 
     fireEvent.click(submitButton);
 
     await waitFor(() => {
       expect(mockSignup).toHaveBeenCalledWith({
-        firstName: "John",
-        lastName: "Doe",
-        email: "john.doe@example.com",
+        firstName: "Abdullah",
+        lastName: "Umer",
+        email: "abd@gmail.com",
         password: "password123"
       });
       expect(toast).toHaveBeenCalledWith({


### PR DESCRIPTION
## Changes

- fixes for tests to pass after previous patch changes
- sample data fixtures for all frontend tests
- allowing empty search query to view all movies